### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pydantic~=2.10.6
 requests~=2.32.3
 librosa~=0.10.2
 numpy~=2.1.3
+werkzeug==3.1.3

--- a/src/main/backendService/service/JukeBoxHeroService.py
+++ b/src/main/backendService/service/JukeBoxHeroService.py
@@ -5,6 +5,7 @@ import librosa
 from librosa.feature import chroma_cqt
 import numpy as np
 import time
+from werkzeug.utils import secure_filename
 
 logging.basicConfig(
     level=logging.INFO,
@@ -12,6 +13,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+SAFE_DIRECTORY = '/safe/directory'
 
 def process_job(url):
     downloaded_file = download_track(url)
@@ -21,10 +23,13 @@ def process_job(url):
 
 def download_track(url):
     response = requests.get(url)
-    filename = os.path.basename(url)
-    with open(filename, 'wb') as file:
+    filename = secure_filename(os.path.basename(url))
+    fullpath = os.path.normpath(os.path.join(SAFE_DIRECTORY, filename))
+    if not fullpath.startswith(SAFE_DIRECTORY):
+        raise Exception("Invalid file path")
+    with open(fullpath, 'wb') as file:
         file.write(response.content)
-    return filename
+    return fullpath
 
 
 def get_metadata(filename):


### PR DESCRIPTION
Potential fix for [https://github.com/stevegreghatch/juke-box-hero/security/code-scanning/3](https://github.com/stevegreghatch/juke-box-hero/security/code-scanning/3)

To fix the problem, we need to ensure that the `filename` derived from the `url` is safe to use. We can achieve this by normalizing the path and ensuring it is within a designated safe directory. Additionally, we can use the `werkzeug.utils.secure_filename` function to sanitize the filename.

1. Define a safe directory where the files will be stored.
2. Normalize the path and ensure it is within the safe directory.
3. Use `werkzeug.utils.secure_filename` to sanitize the filename.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
